### PR TITLE
解决springboot devtools模式下，重复启动tio服务造成端口冲突问题

### DIFF
--- a/tio-websocket-spring-boot-starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerBootstrap.java
+++ b/tio-websocket-spring-boot-starter/src/main/java/org/tio/websocket/starter/TioWebSocketServerBootstrap.java
@@ -28,6 +28,9 @@ public final class TioWebSocketServerBootstrap {
     private static final Logger logger = LoggerFactory.getLogger(TioWebSocketServerBootstrap.class);
 
     private static final String GROUP_CONTEXT_NAME = "tio-websocket-spring-boot-starter";
+    
+    //20190920:ecoolper,解决springboot devtools模式下，重复启动tio服务造成端口冲突问题
+    private boolean started = false;
 
     private TioWebSocketServerProperties serverProperties;
     private TioWebSocketServerClusterProperties clusterProperties;
@@ -121,6 +124,11 @@ public final class TioWebSocketServerBootstrap {
     }
 
     public void contextInitialized() {
+    	if(started) {
+    		logger.info("initialize tio websocket server");
+    		return;
+    	}
+    	
         logger.info("initialize tio websocket server");
         try {
             initTioWebSocketConfig();
@@ -128,6 +136,7 @@ public final class TioWebSocketServerBootstrap {
             initTioWebSocketServerGroupContext();
 
             start();
+            started = true;
         }
         catch (Throwable e) {
             logger.error("Cannot bootstrap tio websocket server :", e);


### PR DESCRIPTION
1、开发过程中使用到springboot devtools插件；
2、修改业务代码会重启启动springboot服务，会重新启动tio服务，造成端口冲突，此代码是解决此问题；
3、2019年9月19日已提交的代码不能完全解决此问题，9月20日再次修改后提交，已测试；